### PR TITLE
Fix precommit

### DIFF
--- a/src/tissue_map_tools/mesh_util.py
+++ b/src/tissue_map_tools/mesh_util.py
@@ -171,7 +171,7 @@ def rewrite_index_with_empty_fragments(path, current_lod_fragments):
     vertex_offsets, file_content = unpack_and_remove("f", num_lods * 3, file_content)
 
     num_fragments_per_lod, file_content = unpack_and_remove("I", num_lods, file_content)
-    if type(num_fragments_per_lod) == int:
+    if isinstance(num_fragments_per_lod, int):
         num_fragments_per_lod = np.array([num_fragments_per_lod])
 
     all_current_fragment_positions = []
@@ -185,7 +185,7 @@ def rewrite_index_with_empty_fragments(path, current_lod_fragments):
         fragment_offsets, file_content = unpack_and_remove(
             "I", num_fragments_per_lod[lod], file_content
         )
-        if type(fragment_offsets) == int:
+        if isinstance(fragment_offsets, int):
             fragment_offsets = np.array([fragment_offsets])
         all_current_fragment_positions.append(fragment_positions.astype(int))
         all_current_fragment_offsets.append(fragment_offsets.tolist())


### PR DESCRIPTION
I fixed the `pre-commit` errors (since `pre-commit` is not activated for this repo in GitHub, below I copy-paste the errors I was getting before this PR).

```
prettier.................................................................Passed
mypy.....................................................................Passed
ruff.....................................................................Failed
- hook id: ruff
- exit code: 1

src/tissue_map_tools/_util.py:193:13: E722 Do not use bare `except`
    |
191 |                 df = pd.DataFrame(dataOut, columns=columns)
192 |                 df.to_csv(csv_out, index=False, header=True)
193 |             except:
    |             ^^^^^^ E722
194 |                 print("Error", _key)
195 |     print("done")
    |

src/tissue_map_tools/_util.py:352:9: E722 Do not use bare `except`
    |
350 |             df = pd.DataFrame(dataOut, columns=columns)
351 |             df.to_csv(csv_out, index=False, header=True)
352 |         except:
    |         ^^^^^^ E722
353 |             print("Error with", _key)
    |

src/tissue_map_tools/_util.py:393:5: F841 Local variable `results` is assigned to but never used
    |
391 |     """Generate decimatated meshes for all ids in `ids`, over all lod in `lods`."""
392 |
393 |     results = []
    |     ^^^^^^^ F841
394 |     for current_lod in lods:
395 |         os.makedirs(f"{output_path}/mesh_lods/s{current_lod}", exist_ok=True)
    |
    = help: Remove assignment to unused variable `results`

src/tissue_map_tools/_util.py:472:36: F821 Undefined name `mesh_util`
    |
470 |         dictionary[fragment_pos] = fragment
471 |     else:
472 |         dictionary[fragment_pos] = mesh_util.Fragment(
    |                                    ^^^^^^^^^ F821
473 |             vertices, faces, [lod_0_fragment_pos]
474 |         )
    |

src/tissue_map_tools/_util.py:576:23: F821 Undefined name `mesh_util`
    |
574 |         fragments: List of `CompressedFragments` (named tuple)
575 |     """
576 |     vertices, faces = mesh_util.mesh_loader(mesh_path)
    |                       ^^^^^^^^^ F821
577 |
578 |     combined_fragments_dictionary = {}
    |

src/tissue_map_tools/_util.py:677:28: F821 Undefined name `mesh_util`
    |
675 |             if len(draco_bytes) > 12:
676 |                 # Then the mesh is not empty
677 |                 fragment = mesh_util.CompressedFragment(
    |                            ^^^^^^^^^ F821
678 |                     draco_bytes,
679 |                     np.asarray(fragment_pos),
    |

src/tissue_map_tools/_util.py:704:23: F821 Undefined name `mesh_util`
    |
702 |             mesh_path = f"{output_path}/mesh_lods/s{current_lod}/{id}.ply"
703 |
704 |         vertices, _ = mesh_util.mesh_loader(mesh_path)
    |                       ^^^^^^^^^ F821
705 |
706 |         if vertices is not None:
    |

src/tissue_map_tools/_util.py:766:13: F841 Local variable `results` is assigned to but never used
    |
764 |                         )
765 |
766 |             results = []
    |             ^^^^^^^ F841
767 |
768 |             # Remove empty slabs
    |
    = help: Remove assignment to unused variable `results`

src/tissue_map_tools/_util.py:781:13: F821 Undefined name `mesh_util`
    |
779 |             del decomposition_results
780 |
781 |             mesh_util.write_mesh_files(
    |             ^^^^^^^^^ F821
782 |                 f"{output_path}/multires",
783 |                 f"{id}",
    |

src/tissue_map_tools/_util.py:830:5: F841 Local variable `columns` is assigned to but never used
    |
828 |     chunk_shape = data.chunks
829 |
830 |     columns = ["id", "voxels", "chunk_keys"]
    |     ^^^^^^^ F841
831 |     dataOut = []
    |
    = help: Remove assignment to unused variable `columns`

src/tissue_map_tools/_util.py:831:5: F841 Local variable `dataOut` is assigned to but never used
    |
830 |     columns = ["id", "voxels", "chunk_keys"]
831 |     dataOut = []
    |     ^^^^^^^ F841
832 |
833 |     print("Starting the Object Creation")
    |
    = help: Remove assignment to unused variable `dataOut`

src/tissue_map_tools/_util.py:896:9: F821 Undefined name `mesh_util`
    |
895 |         multires_output_path = f"{temp_mesh_dir}/multires"
896 |         mesh_util.write_segment_properties_file(multires_output_path)
    |         ^^^^^^^^^ F821
897 |         mesh_util.write_info_file(multires_output_path)
898 |         # except:
    |

src/tissue_map_tools/_util.py:897:9: F821 Undefined name `mesh_util`
    |
895 |         multires_output_path = f"{temp_mesh_dir}/multires"
896 |         mesh_util.write_segment_properties_file(multires_output_path)
897 |         mesh_util.write_info_file(multires_output_path)
    |         ^^^^^^^^^ F821
898 |         # except:
899 |         #     print("Error with", _key)
    |

src/tissue_map_tools/mesh_util.py:174:8: E721 Use `is` and `is not` for type comparisons, or `isinstance()` for isinstance checks
    |
173 |     num_fragments_per_lod, file_content = unpack_and_remove("I", num_lods, file_content)
174 |     if type(num_fragments_per_lod) == int:
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ E721
175 |         num_fragments_per_lod = np.array([num_fragments_per_lod])
    |

src/tissue_map_tools/mesh_util.py:188:12: E721 Use `is` and `is not` for type comparisons, or `isinstance()` for isinstance checks
    |
186 |             "I", num_fragments_per_lod[lod], file_content
187 |         )
188 |         if type(fragment_offsets) == int:
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ E721
189 |             fragment_offsets = np.array([fragment_offsets])
190 |         all_current_fragment_positions.append(fragment_positions.astype(int))
    |

Found 15 errors.
No fixes available (4 hidden fixes can be enabled with the `--unsafe-fixes` option).

ruff-format..............................................................Passed
```