### PR TITLE
Simplify API to view in neuroglancer

### DIFF
--- a/src/tissue_map_tools/view.py
+++ b/src/tissue_map_tools/view.py
@@ -6,36 +6,25 @@ from pathlib import Path
 
 def view_precomputed_in_neuroglancer(
     local_data_path: str,
+    layer_name: str | None = None,
+    mesh_layer_name: str | None = None,
+    mesh_labels: list[int] | None = None,
     port: int = 10001,
     viewer: neuroglancer.Viewer | None = None,
-    layer_name: str | None = None,
     open_browser: bool = True,
     host_local_data: bool = True,
-    unique_labels: list[int] | None = None,
 ) -> neuroglancer.Viewer:
+    if mesh_labels is not None and mesh_layer_name is None:
+        raise ValueError(
+            "mesh_layer_name must be provided if mesh_labels are specified."
+        )
+
     if viewer is None:
         viewer = neuroglancer.Viewer()
 
-    data_type: str | None = None
-    try:
-        cv = CloudVolume(cloudpath=local_data_path)
-    except KeyError as e:
-        if str(e) == "'scales'":
-            parent = Path(local_data_path).parent
-            mesh_dir = Path(local_data_path).name
-            cv = CloudVolume(cloudpath=str(parent), mesh_dir=mesh_dir)
-            data_type = "mesh"
-        else:
-            raise e
-    if data_type is None:
-        data_type = cv.info["type"]
+    cv = CloudVolume(cloudpath=local_data_path)
+    data_type = cv.info["type"]
     layer_name = layer_name if layer_name is not None else Path(cv.layerpath).name
-
-    if unique_labels is not None and data_type != "mesh":
-        raise ValueError(
-            "unique_labels can only be used with mesh data type, but the data type "
-            f"is: {data_type}"
-        )
 
     if viewer is None:
         viewer = neuroglancer.Viewer()
@@ -49,14 +38,14 @@ def view_precomputed_in_neuroglancer(
             s.layers[layer_name] = neuroglancer.SegmentationLayer(
                 source=url,
             )
-        elif data_type == "mesh":
-            s.layers[layer_name] = neuroglancer.SegmentationLayer(
-                # s.layers[layer_name] = neuroglancer.SingleMeshLayer(
-                source=url + f"/{Path(local_data_path).name}",
-                segments=unique_labels,
-            )
         else:
             raise ValueError(f"Unsupported data type: {data_type}")
+
+        if mesh_layer_name is not None:
+            s.layers[mesh_layer_name] = neuroglancer.SegmentationLayer(
+                source=url + f"/{mesh_layer_name}",
+                segments=mesh_labels,
+            )
 
     if open_browser:
         webbrowser.open(url=viewer.get_viewer_url(), new=2)
@@ -76,15 +65,6 @@ if __name__ == "__main__":
     viewer = view_precomputed_in_neuroglancer(
         local_data_path="../../out/20_1_gloms_precomputed",
         layer_name=None,
-        open_browser=False,
-        host_local_data=False,
-        # unique_labels=unique_labels,
-    )
-    view_precomputed_in_neuroglancer(
-        viewer=viewer,
-        local_data_path="../../out/20_1_gloms_precomputed/mesh_mip_0_err_40",
-        layer_name="meshes",
-        open_browser=True,
-        host_local_data=True,
-        unique_labels=unique_labels,
+        mesh_layer_name="mesh_mip_0_err_40",
+        mesh_labels=unique_labels,
     )


### PR DESCRIPTION
To view a segmentation and their meshes one needed to do two calls (this was to promote a modular design). Unfortunately it seems that neuroglancer doesn't show the meshes if a segmentation is also not shown. So I modified the API to do everything in one call (and actually it feels easier to work with the new API).