### PR TITLE
Update MERFISH conversion script to store a two-channel image and use multiscales

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ src/tissue_map_tools/__pycache__
 out/*
 .DS_Store
 sandbox/*
+__pycache__/

--- a/examples/0_merfish_mouse_ileum.py
+++ b/examples/0_merfish_mouse_ileum.py
@@ -486,19 +486,5 @@ sdata["cells_baysor"] = processed
 sdata.write(out_path / "merfish_mouse_ileum.sdata.zarr", overwrite=True)
 
 
-# Crop
-max_y = 9392
-max_x = 5721
-crop_size = 500
-cropped_sdata = sdata.query.bounding_box(
-    axes=["x", "y"],
-    min_coordinate=[np.floor(max_x/2 - crop_size/2), np.floor(max_y/2 - crop_size/2)],
-    max_coordinate=[np.floor(max_x/2 + crop_size/2), np.floor(max_y/2 + crop_size/2)],
-    target_coordinate_system="global",
-    #filter_table=False
-)
-
-cropped_sdata.write(out_path / "merfish_mouse_ileum_cropped.sdata.zarr", overwrite=True)
-
 # ##
 # Interactive(sdata)


### PR DESCRIPTION
This PR updates the MERFISH SpatialData conversion script to output a single two-channel image (rather than two single-channel images) with channel names and use scale_factors to create three-resolution image pyramids for the image and labels elements. It also updates the output path for the object to use the `out` directory.