### PR TITLE
faster spatial index calculation for points

### DIFF
--- a/src/tissue_map_tools/config.py
+++ b/src/tissue_map_tools/config.py
@@ -3,3 +3,4 @@
 # to help catch issues early. Set to False to suppress verbose output.
 PRINT_DEBUG = True
 VISUAL_DEBUG = False
+VERIFY_ENCODING = False

--- a/src/tissue_map_tools/converters.py
+++ b/src/tissue_map_tools/converters.py
@@ -303,32 +303,18 @@ def from_spatialdata_points_to_precomputed_points(
 
     ##
     # compute annotations_by_index_id, used in write_annotation_id_index()
-    annotations_by_index_id: dict[
-        int, tuple[list[float], dict[str, Any], dict[str, list[int]]]
-    ] = {}
-    # convert all categorical columns to codes and store them in a separate dataframe
-    points_categorical = points.select_dtypes(include=["category"])
-    for col in points_categorical.columns:
-        points_categorical[col] = points[col].cat.codes
-
-    # important: neuroglancer doesn't know about the df.index, it just knows about
-    # the "iloc". Also, in iterrows() we do not consider the index, using an enumerate
-    # instead
     # TODO: actually, we should probably have the id of the points equal to the index,
     #  instead of resetting it to a contiguous range
-    for i, row in enumerate(points.itertuples()):
-        coords = [getattr(row, col) for col in spatial_columns]
-        row_dict = row._asdict()
-        properties_values = {}
-        for k, v in row_dict.items():
-            if k in spatial_columns or k == "Index":
-                continue
-            if points[k].dtype == "category":
-                k_index = points_categorical.columns.get_loc(k)
-                v = points_categorical.iloc[i, k_index]
-            properties_values[k] = v
-        relationships_values: dict[str, list[int]] = {}
-        annotations_by_index_id[i] = (coords, properties_values, relationships_values)
+    prop_columns = [col for col in points.columns if col not in spatial_columns]
+    prop_df = points[prop_columns].copy()
+    for col in prop_columns:
+        if points[col].dtype == "category":
+            prop_df[col] = points[col].cat.codes
+    prop_records: list[dict[str, Any]] = prop_df.to_dict("records")
+    coords_list: list[list[float]] = points[spatial_columns].to_numpy().tolist()
+    annotations_by_index_id: dict[
+        int, tuple[list[float], dict[str, Any], dict[str, list[int]]]
+    ] = {i: (coords_list[i], prop_records[i], {}) for i in range(len(points))}
 
     ##
     # compute annotations_by_relationship_id, used in write_related_object_id_index()

--- a/src/tissue_map_tools/data_model/annotations.py
+++ b/src/tissue_map_tools/data_model/annotations.py
@@ -18,7 +18,7 @@ from tissue_map_tools.data_model.shard_utils import (
     chunk_name_to_morton_code,
     morton_code_to_chunk_name,
 )
-from tissue_map_tools.config import PRINT_DEBUG, VISUAL_DEBUG
+from tissue_map_tools.config import PRINT_DEBUG, VISUAL_DEBUG, VERIFY_ENCODING
 from pathlib import PurePosixPath
 import re
 import struct
@@ -325,18 +325,18 @@ def encode_positions_and_properties_via_single_annotation(
         else:
             raise ValueError(f"Unknown property type: {prop.type}")
         buf += packed
-        # safety check
-        if prop.type in ["rgb", "rgba"]:
-            unpacked = struct.unpack_from("<" + str(len(value)) + "B", packed)
-            value_check = value
-        else:
-            unpacked = struct.unpack_from(fmt, packed)
-            value_check = (value,)
-        if not np.allclose(unpacked, value_check):
-            raise ValueError(
-                f"Value mismatch for property '{prop.id}': original {value}, unpacked "
-                f"{unpacked}. Please report this bug."
-            )
+        if VERIFY_ENCODING:
+            if prop.type in ["rgb", "rgba"]:
+                unpacked = struct.unpack_from("<" + str(len(value)) + "B", packed)
+                value_check = value
+            else:
+                unpacked = struct.unpack_from(fmt, packed)
+                value_check = (value,)
+            if not np.allclose(unpacked, value_check):
+                raise ValueError(
+                    f"Value mismatch for property '{prop.id}': original {value}, unpacked "
+                    f"{unpacked}. Please report this bug."
+                )
 
     # 3. Pad to 4-byte boundary
     pad = (4 - (len(buf) % 4)) % 4


### PR DESCRIPTION
@EricMoerthVis reported that computing and writing the sharded spatial index for 12 million points took 30 min for him (probably due to the particular properties used, since we tested it with more points earlier). On a MacBook Pro M4 Pro 48GB RAM, I estimated that the same operation for 10 million points would take 30 minutes.

This PR massively speeds up the operation. Writing 10 million points (script below) is completed in under 3 minutes.

```python
"""10 million sharded points — target script for py-spy profiling."""

import contextlib                                                                                                                               
import io
import tempfile
from pathlib import Path

import numpy as np
import pandas as pd

import tissue_map_tools.data_model.annotations as ann_module
from tissue_map_tools.converters import from_spatialdata_points_to_precomputed_points

N = 10_000_000
LIMIT = N // 100  # 1000
N_CATEGORIES = 200
REGION_CATEGORIES = [f"region_{i:03d}" for i in range(N_CATEGORIES)]

rng = np.random.default_rng(42)
codes = rng.integers(0, N_CATEGORIES, N)
df = pd.DataFrame(
    {
        "x": rng.random(N).astype(np.float32) * 10_000,
        "y": rng.random(N).astype(np.float32) * 10_000,
        "z": rng.random(N).astype(np.float32) * 1_000,
        "cell_id": rng.integers(-(2**31), 2**31 - 1, N, dtype=np.int32),
        "region_name": pd.Categorical.from_codes(codes, categories=REGION_CATEGORIES),
        "pred_name": rng.integers(-128, 127, N).astype(np.int8),
        "cd8_val": rng.random(N).astype(np.float32),
        "muc2_val": rng.random(N).astype(np.float32),
        "id": rng.integers(-(2**31), 2**31 - 1, N, dtype=np.int32),
    }
)

with tempfile.TemporaryDirectory() as tmpdir:
    out = Path(tmpdir) / "sharded"
    out.mkdir()
    ann_module.RNG = np.random.default_rng(0)
    with contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(io.StringIO()):
        from_spatialdata_points_to_precomputed_points(
            points=df,
            precomputed_path=out,
            points_name="points",
            limit=LIMIT,
            starting_grid_shape=(1, 1, 1),
            sharded=True,
        )
```